### PR TITLE
Fix memset usage in FTL project

### DIFF
--- a/ftl.c
+++ b/ftl.c
@@ -816,7 +816,7 @@ int ftl_write_vb_table_detail_to_csv(char* test_case)
     // Determine valid count or not.
     unsigned int total_pages = TOTAL_BLOCKS * PAGES_PER_BLOCK;// sizeof(g_p2l_table) / sizeof(g_p2l_table[0]);
     unsigned int* pages_valid_status = (unsigned int*)malloc(total_pages * sizeof(unsigned int));
-    memset(pages_valid_status, 0, total_pages);
+    memset(pages_valid_status, 0, total_pages * sizeof(unsigned int));
 
     unsigned int total_valid_pages = 0;    
     for (unsigned int i = 0; i < total_pages; i++) 

--- a/main.c
+++ b/main.c
@@ -231,7 +231,7 @@ int main(int argc, char **argv) {
         }
 
         // initial waf record.
-        memset(g_waf_record_data, 0, NUM_LOOPS);
+        memset(g_waf_record_data, 0, NUM_LOOPS * sizeof(waf_records_t));
 
         char* test_case;
         switch (select)


### PR DESCRIPTION
## Summary
- fix array zeroing in `ftl_write_vb_table_detail_to_csv`
- fix zeroing of WAF record data in `main.c`

## Testing
- `gcc -g main.c ftl.c vblist.c freeVB.c -o Bin/main.exe` *(fails: windows.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d190eca4c832a82cf1d745879a015